### PR TITLE
Load REST API speed enhancement

### DIFF
--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/domain/service/HackerNewsService.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/domain/service/HackerNewsService.java
@@ -1,6 +1,7 @@
 package com.setiawanpaiman.sunnyreader.domain.service;
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import com.setiawanpaiman.sunnyreader.Constants;
 import com.setiawanpaiman.sunnyreader.data.model.Comment;
@@ -15,8 +16,11 @@ import rx.functions.Func1;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class HackerNewsService implements IHackerNewsService {
+
+    private static final String TAG = HackerNewsService.class.getName();
 
     private final HackerNewsApi mHackerNewsApi;
     private final HackerNewsPersistent mHackerNewsPersistent;
@@ -28,20 +32,28 @@ public class HackerNewsService implements IHackerNewsService {
     }
 
     @Override
-    public Observable<Story> getTopStories() {
+    public Observable<List<Story>> getTopStories() {
         return getTopStories(Constants.FIRST_PAGE);
     }
 
     @Override
-    public Observable<Story> getTopStories(int page) {
+    public Observable<List<Story>> getTopStories(int page) {
+        Log.i(TAG, "getTopStories " + page);
+        final List<Long> topStoriesId = new ArrayList<>();
         return getTopStoriesId(page)
-                .concatMap(new Func1<List<Long>, Observable<Long>>() {
+                /**
+                 * concatMap can be used here to maintain the order of Stories, but flatMap was used instead.
+                 * This is because: in my personal benchmark result, the performance of concatMap is terrible.
+                 * Using concatMap is far more slower than ordering the Stories manually by using
+                 * combination of Map and List (see the last operator applied here).
+                 */
+                .flatMap(new Func1<List<Long>, Observable<Long>>() {
                     @Override
                     public Observable<Long> call(List<Long> storyIds) {
+                        topStoriesId.addAll(storyIds);
                         return Observable.from(storyIds);
                     }
-                })
-                .concatMap(new Func1<Long, Observable<Story>>() {
+                }).flatMap(new Func1<Long, Observable<Story>>() {
                     @Override
                     public Observable<Story> call(final Long storyId) {
                         return mHackerNewsApi.getStory(storyId)
@@ -53,22 +65,36 @@ public class HackerNewsService implements IHackerNewsService {
                                 })
                                 .onErrorResumeNext(mHackerNewsPersistent.getStory(storyId));
                     }
-                })
-                .filter(new Func1<Story, Boolean>() {
+                }).filter(new Func1<Story, Boolean>() {
                     @Override
                     public Boolean call(Story story) {
                         return story != null;
+                    }
+                }).toMap(new Func1<Story, Long>() {
+                    @Override
+                    public Long call(Story story) {
+                        return story.getId();
+                    }
+                }).map(new Func1<Map<Long, Story>, List<Story>>() {
+                    @Override
+                    public List<Story> call(Map<Long, Story> storiesMap) {
+                        List<Story> stories = new ArrayList<>();
+                        for (Long id : topStoriesId) {
+                            if (storiesMap.containsKey(id)) stories.add(storiesMap.get(id));
+                        }
+                        return stories;
                     }
                 });
     }
 
     @Override
-    public Observable<Comment> getComments(@NonNull Story story) {
+    public Observable<List<Comment>> getComments(@NonNull Story story) {
         return getComments(story, Constants.FIRST_PAGE);
     }
 
     @Override
-    public Observable<Comment> getComments(@NonNull Story story, int page) {
+    public Observable<List<Comment>> getComments(@NonNull Story story, int page) {
+        Log.i(TAG, "getComments " + page);
         List<Long> subCommentIds = story.getCommentIds();
         int lBound = Math.min(subCommentIds.size(), (page - 1) * Constants.PER_PAGE);
         int uBound = Math.min(subCommentIds.size(), lBound + Constants.PER_PAGE);
@@ -76,9 +102,15 @@ public class HackerNewsService implements IHackerNewsService {
         return getComments(subCommentIds, Constants.FIRST_DEPTH);
     }
 
-    private Observable<Comment> getComments(List<Long> commentIds, final int depth) {
+    private Observable<List<Comment>> getComments(final List<Long> commentIds, final int depth) {
         return Observable.from(commentIds)
-                .concatMap(new Func1<Long, Observable<Comment>>() {
+                /**
+                 * concatMap can be used here to maintain the order of Comments, but flatMap was used instead.
+                 * This is because: in my personal benchmark result, the performance of concatMap is terrible.
+                 * Using concatMap is far more slower than ordering the Comments manually by using
+                 * combination of Map and List (see the last operator applied here).
+                 */
+                .flatMap(new Func1<Long, Observable<Comment>>() {
                     @Override
                     public Observable<Comment> call(Long commentId) {
                         return getCommentAndReplies(commentId, depth);
@@ -87,6 +119,16 @@ public class HackerNewsService implements IHackerNewsService {
                     @Override
                     public Boolean call(Comment comment) {
                         return comment != null && !comment.isDeleted();
+                    }
+                }).toMap(new Func1<Comment, Long>() {
+                    @Override
+                    public Long call(Comment comment) {
+                        return comment.getId();
+                    }
+                }).map(new Func1<Map<Long, Comment>, List<Comment>>() {
+                    @Override
+                    public List<Comment> call(Map<Long, Comment> commentsMap) {
+                        return mapIdsToComments(commentIds, commentsMap);
                     }
                 });
     }
@@ -104,18 +146,40 @@ public class HackerNewsService implements IHackerNewsService {
                 .onErrorResumeNext(mHackerNewsPersistent.getComment(commentId))
                 .flatMap(new Func1<Comment, Observable<Comment>>() {
                     @Override
-                    public Observable<Comment> call(Comment comment) {
-                        List<Long> commentReplyIds = comment != null ?
-                                comment.getCommentIds() : new ArrayList<Long>();
-                        if (comment != null) comment.setDepth(depth);
-                        if (commentReplyIds.size() > 0) {
-                            return Observable.concat(Observable.just(comment),
-                                    getComments(commentReplyIds, depth + 1));
-                        } else {
-                            return Observable.just(comment);
-                        }
+                    public Observable<Comment> call(final Comment comment) {
+                        return getReplies(comment, depth);
                     }
                 });
+    }
+
+    private Observable<Comment> getReplies(Comment comment, int depth) {
+        List<Long> replyIds = comment != null ? comment.getCommentIds() : new ArrayList<Long>();
+        if (comment != null) comment.setDepth(depth);
+        if (replyIds.size() > 0) {
+            return Observable.concat(
+                    Observable.just(comment),
+                    getComments(replyIds, depth + 1)
+                            .flatMap(new Func1<List<Comment>, Observable<Comment>>() {
+                                @Override
+                                public Observable<Comment> call(List<Comment> comments) {
+                                    return Observable.from(comments);
+                                }
+                            }));
+        } else {
+            return Observable.just(comment);
+        }
+    }
+
+    private List<Comment> mapIdsToComments(List<Long> commentIds, Map<Long, Comment> commentsMap) {
+        List<Comment> comments = new ArrayList<>();
+        for (Long id : commentIds) {
+            if (commentsMap.containsKey(id)) {
+                Comment comment = commentsMap.get(id);
+                comments.add(comment);
+                comments.addAll(mapIdsToComments(comment.getCommentIds(), commentsMap));
+            }
+        }
+        return comments;
     }
 
     private Observable<List<Long>> retrieveTopStoriesId(final int start, final int count) {
@@ -129,8 +193,7 @@ public class HackerNewsService implements IHackerNewsService {
                                 mHackerNewsPersistent.saveTopStories(longs);
                                 return mHackerNewsPersistent.getTopStories(start, count);
                             }
-                        })
-                        .onErrorResumeNext(mHackerNewsPersistent.getTopStories(start, count));
+                        }).onErrorResumeNext(mHackerNewsPersistent.getTopStories(start, count));
             }
         });
     }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/domain/service/HackerNewsService.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/domain/service/HackerNewsService.java
@@ -32,15 +32,15 @@ public class HackerNewsService implements IHackerNewsService {
     }
 
     @Override
-    public Observable<List<Story>> getTopStories() {
-        return getTopStories(Constants.FIRST_PAGE);
+    public Observable<List<Story>> getTopStories(int count) {
+        return getTopStories(Constants.FIRST_PAGE, count);
     }
 
     @Override
-    public Observable<List<Story>> getTopStories(int page) {
+    public Observable<List<Story>> getTopStories(int page, int count) {
         Log.i(TAG, "getTopStories " + page);
         final List<Long> topStoriesId = new ArrayList<>();
-        return getTopStoriesId(page)
+        return getTopStoriesId(page, count)
                 /**
                  * concatMap can be used here to maintain the order of Stories, but flatMap was used instead.
                  * This is because: in my personal benchmark result, the performance of concatMap is terrible.
@@ -88,16 +88,16 @@ public class HackerNewsService implements IHackerNewsService {
     }
 
     @Override
-    public Observable<List<Comment>> getComments(@NonNull Story story) {
-        return getComments(story, Constants.FIRST_PAGE);
+    public Observable<List<Comment>> getComments(@NonNull Story story, int count) {
+        return getComments(story, Constants.FIRST_PAGE, count);
     }
 
     @Override
-    public Observable<List<Comment>> getComments(@NonNull Story story, int page) {
+    public Observable<List<Comment>> getComments(@NonNull Story story, int page, int count) {
         Log.i(TAG, "getComments " + page);
         List<Long> subCommentIds = story.getCommentIds();
-        int lBound = Math.min(subCommentIds.size(), (page - 1) * Constants.PER_PAGE);
-        int uBound = Math.min(subCommentIds.size(), lBound + Constants.PER_PAGE);
+        int lBound = Math.min(subCommentIds.size(), (page - 1) * count);
+        int uBound = Math.min(subCommentIds.size(), lBound + count);
         subCommentIds = subCommentIds.subList(lBound, uBound);
         return getComments(subCommentIds, Constants.FIRST_DEPTH);
     }
@@ -198,9 +198,8 @@ public class HackerNewsService implements IHackerNewsService {
         });
     }
 
-    private Observable<List<Long>> getTopStoriesId(int page) {
-        int start = (page - 1) * Constants.PER_PAGE;
-        int count = Constants.PER_PAGE;
+    private Observable<List<Long>> getTopStoriesId(int page, int count) {
+        int start = (page - 1) * count;
         if (page == Constants.FIRST_PAGE) {
             return retrieveTopStoriesId(start, count);
         } else {

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/domain/service/IHackerNewsService.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/domain/service/IHackerNewsService.java
@@ -5,33 +5,35 @@ import com.setiawanpaiman.sunnyreader.data.model.Story;
 
 import rx.Observable;
 
+import java.util.List;
+
 public interface IHackerNewsService {
 
     /**
      * Get the first page of top stories
-     * @return Top stories emitted in order as Observable
+     * @return List of Top stories emitted in order as Observable
      */
-    Observable<Story> getTopStories();
+    Observable<List<Story>> getTopStories();
 
     /**
      * Get the top stories in page specified by {@code page} parameter
      * @param page The page where top stories will be retrieved
-     * @return Top stories emitted in order as Observable
+     * @return List of Top stories emitted in order as Observable
      */
-    Observable<Story> getTopStories(int page);
+    Observable<List<Story>> getTopStories(int page);
 
     /**
      * Get Story {@code story} comments in the first page
      * @param story The story which comments will be retrieved
-     * @return Comments emitted in order as Observable
+     * @return List of Comments emitted in order as Observable
      */
-    Observable<Comment> getComments(Story story);
+    Observable<List<Comment>> getComments(Story story);
 
     /**
      * Get Story {@code story} comments in page specified by {@code page} parameter
      * @param story The story which comments will be retrieved
      * @param page The page where comments will be retrieved
-     * @return Comments emitted in order as Observable
+     * @return List of Comments emitted in order as Observable
      */
-    Observable<Comment> getComments(Story story, int page);
+    Observable<List<Comment>> getComments(Story story, int page);
 }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/domain/service/IHackerNewsService.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/domain/service/IHackerNewsService.java
@@ -13,21 +13,21 @@ public interface IHackerNewsService {
      * Get the first page of top stories
      * @return List of Top stories emitted in order as Observable
      */
-    Observable<List<Story>> getTopStories();
+    Observable<List<Story>> getTopStories(int count);
 
     /**
      * Get the top stories in page specified by {@code page} parameter
      * @param page The page where top stories will be retrieved
      * @return List of Top stories emitted in order as Observable
      */
-    Observable<List<Story>> getTopStories(int page);
+    Observable<List<Story>> getTopStories(int page, int count);
 
     /**
      * Get Story {@code story} comments in the first page
      * @param story The story which comments will be retrieved
      * @return List of Comments emitted in order as Observable
      */
-    Observable<List<Comment>> getComments(Story story);
+    Observable<List<Comment>> getComments(Story story, int count);
 
     /**
      * Get Story {@code story} comments in page specified by {@code page} parameter
@@ -35,5 +35,5 @@ public interface IHackerNewsService {
      * @param page The page where comments will be retrieved
      * @return List of Comments emitted in order as Observable
      */
-    Observable<List<Comment>> getComments(Story story, int page);
+    Observable<List<Comment>> getComments(Story story, int page, int count);
 }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/adapter/CommentAdapter.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/adapter/CommentAdapter.java
@@ -17,6 +17,7 @@ import com.setiawanpaiman.sunnyreader.data.model.Comment;
 import com.setiawanpaiman.sunnyreader.data.model.Story;
 import com.setiawanpaiman.sunnyreader.util.AndroidUtils;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class CommentAdapter extends EndlessListAdapter<Comment, RecyclerView.ViewHolder> {
@@ -69,6 +70,18 @@ public class CommentAdapter extends EndlessListAdapter<Comment, RecyclerView.Vie
         }
         mData.add(result);
         notifyItemInserted(mData.size());
+    }
+
+    @Override
+    public void addAll(List<Comment> results, boolean refresh) {
+        if (refresh) {
+            mData.clear();
+            notifyDataSetChanged();
+        }
+        int lastSize = mData.size();
+        int newCount = results.size();
+        mData.addAll(results);
+        notifyItemRangeInserted(lastSize + 1, newCount);
     }
 
     @Override

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/adapter/EndlessListAdapter.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/adapter/EndlessListAdapter.java
@@ -80,7 +80,7 @@ public abstract class EndlessListAdapter<T, VH extends RecyclerView.ViewHolder>
         int lastSize = mData.size();
         int newCount = results.size();
         mData.addAll(results);
-        notifyItemRangeInserted(lastSize - 1, newCount);
+        notifyItemRangeInserted(lastSize, newCount);
     }
 
     @Override

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/fragment/EndlessListFragment.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/fragment/EndlessListFragment.java
@@ -20,8 +20,10 @@ import com.setiawanpaiman.sunnyreader.ui.presenter.EndlessListContract;
 import com.setiawanpaiman.sunnyreader.ui.widget.EndlessRecyclerView;
 import com.setiawanpaiman.sunnyreader.util.AndroidUtils;
 
+import java.util.List;
+
 public abstract class EndlessListFragment<Model extends Parcelable> extends BaseFragment
-        implements EndlessListContract.View<Model>,
+        implements EndlessListContract.View<List<Model>>,
                    SwipeRefreshLayout.OnRefreshListener,
                    EndlessRecyclerView.OnLoadMoreListener {
 
@@ -40,7 +42,7 @@ public abstract class EndlessListFragment<Model extends Parcelable> extends Base
 
     private EndlessListAdapter<Model, ?> mAdapter;
     private boolean mIsLastRequestRefresh;
-    private EndlessListContract.Presenter mPresenter;
+    private EndlessListContract.Presenter<List<Model>> mPresenter;
 
     public EndlessListFragment() {
     }
@@ -94,8 +96,8 @@ public abstract class EndlessListFragment<Model extends Parcelable> extends Base
     }
 
     @Override
-    public void showData(Model data, boolean refresh) {
-        mAdapter.add(data, refresh);
+    public void showData(List<Model> data, boolean refresh) {
+        mAdapter.addAll(data, refresh);
     }
 
     @Override
@@ -110,7 +112,7 @@ public abstract class EndlessListFragment<Model extends Parcelable> extends Base
         mPresenter.loadData(false);
     }
 
-    public abstract EndlessListContract.Presenter<Model> createPresenter();
+    public abstract EndlessListContract.Presenter<List<Model>> createPresenter();
 
     public abstract EndlessListAdapter<Model, ?> createAdapter();
 

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/fragment/StoryDetailFragment.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/fragment/StoryDetailFragment.java
@@ -15,6 +15,8 @@ import com.setiawanpaiman.sunnyreader.util.AndroidUtils;
 
 import rx.schedulers.Schedulers;
 
+import java.util.List;
+
 public class StoryDetailFragment extends EndlessListFragment<Comment> {
 
     private static final String BUNDLE_STORY = "story";
@@ -53,7 +55,7 @@ public class StoryDetailFragment extends EndlessListFragment<Comment> {
     }
 
     @Override
-    public EndlessListContract.Presenter<Comment> createPresenter() {
+    public EndlessListContract.Presenter<List<Comment>> createPresenter() {
         return new StoryDetailPresenter(this, Schedulers.io(),
                 getApplicationComponent().provideHackerNewsService(), mStory);
     }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/fragment/TopStoriesFragment.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/fragment/TopStoriesFragment.java
@@ -15,6 +15,8 @@ import com.setiawanpaiman.sunnyreader.ui.presenter.TopStoriesPresenter;
 
 import rx.schedulers.Schedulers;
 
+import java.util.List;
+
 public class TopStoriesFragment extends EndlessListFragment<Story>
         implements StoryAdapter.OnClickListener {
 
@@ -42,7 +44,7 @@ public class TopStoriesFragment extends EndlessListFragment<Story>
     }
 
     @Override
-    public EndlessListContract.Presenter<Story> createPresenter() {
+    public EndlessListContract.Presenter<List<Story>> createPresenter() {
         return new TopStoriesPresenter(this, Schedulers.io(),
                 getApplicationComponent().provideHackerNewsService());
     }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/EndlessListPresenter.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/EndlessListPresenter.java
@@ -50,7 +50,7 @@ public abstract class EndlessListPresenter<Model> implements EndlessListContract
 
         mCurrentPage = refresh ? Constants.FIRST_PAGE : mCurrentPage + 1;
         mView.setProgressVisibility(true, refresh);
-        mSubscription = createRequestObservable(mCurrentPage)
+        mSubscription = createRequestObservable(mCurrentPage, Constants.PER_PAGE)
                 .doOnUnsubscribe(new Action0() {
                     @Override
                     public void call() {
@@ -94,5 +94,5 @@ public abstract class EndlessListPresenter<Model> implements EndlessListContract
         RxUtils.unsubscribeAll(mSubscription);
     }
 
-    public abstract Observable<Model> createRequestObservable(int page);
+    public abstract Observable<Model> createRequestObservable(int page, int count);
 }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/StoryDetailPresenter.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/StoryDetailPresenter.java
@@ -24,7 +24,7 @@ public class StoryDetailPresenter extends EndlessListPresenter<List<Comment>> {
     }
 
     @Override
-    public Observable<List<Comment>> createRequestObservable(int page) {
-        return mHackerNewsService.getComments(mStory, page);
+    public Observable<List<Comment>> createRequestObservable(int page, int count) {
+        return mHackerNewsService.getComments(mStory, page, count);
     }
 }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/StoryDetailPresenter.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/StoryDetailPresenter.java
@@ -7,12 +7,14 @@ import com.setiawanpaiman.sunnyreader.domain.service.IHackerNewsService;
 import rx.Observable;
 import rx.Scheduler;
 
-public class StoryDetailPresenter extends EndlessListPresenter<Comment> {
+import java.util.List;
+
+public class StoryDetailPresenter extends EndlessListPresenter<List<Comment>> {
 
     private IHackerNewsService mHackerNewsService;
     private Story mStory;
 
-    public StoryDetailPresenter(EndlessListContract.View<Comment> view,
+    public StoryDetailPresenter(EndlessListContract.View<List<Comment>> view,
                                 Scheduler scheduler,
                                 IHackerNewsService hackerNewsService,
                                 Story story) {
@@ -22,7 +24,7 @@ public class StoryDetailPresenter extends EndlessListPresenter<Comment> {
     }
 
     @Override
-    public Observable<Comment> createRequestObservable(int page) {
+    public Observable<List<Comment>> createRequestObservable(int page) {
         return mHackerNewsService.getComments(mStory, page);
     }
 }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/TopStoriesPresenter.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/TopStoriesPresenter.java
@@ -6,11 +6,13 @@ import com.setiawanpaiman.sunnyreader.domain.service.IHackerNewsService;
 import rx.Observable;
 import rx.Scheduler;
 
-public class TopStoriesPresenter extends EndlessListPresenter<Story> {
+import java.util.List;
+
+public class TopStoriesPresenter extends EndlessListPresenter<List<Story>> {
 
     private IHackerNewsService mHackerNewsService;
 
-    public TopStoriesPresenter(EndlessListContract.View<Story> view,
+    public TopStoriesPresenter(EndlessListContract.View<List<Story>> view,
                                Scheduler scheduler,
                                IHackerNewsService hackerNewsService) {
         super(view, scheduler);
@@ -18,7 +20,7 @@ public class TopStoriesPresenter extends EndlessListPresenter<Story> {
     }
 
     @Override
-    public Observable<Story> createRequestObservable(int page) {
+    public Observable<List<Story>> createRequestObservable(int page) {
         return mHackerNewsService.getTopStories(page);
     }
 }

--- a/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/TopStoriesPresenter.java
+++ b/app/src/main/java/com/setiawanpaiman/sunnyreader/ui/presenter/TopStoriesPresenter.java
@@ -20,7 +20,7 @@ public class TopStoriesPresenter extends EndlessListPresenter<List<Story>> {
     }
 
     @Override
-    public Observable<List<Story>> createRequestObservable(int page) {
-        return mHackerNewsService.getTopStories(page);
+    public Observable<List<Story>> createRequestObservable(int page, int count) {
+        return mHackerNewsService.getTopStories(page, count);
     }
 }

--- a/app/src/test/java/com/setiawanpaiman/sunnyreader/testcase/domain/service/HackerNewsServiceTest.java
+++ b/app/src/test/java/com/setiawanpaiman/sunnyreader/testcase/domain/service/HackerNewsServiceTest.java
@@ -1,6 +1,5 @@
 package com.setiawanpaiman.sunnyreader.testcase.domain.service;
 
-import com.setiawanpaiman.sunnyreader.Constants;
 import com.setiawanpaiman.sunnyreader.data.model.Comment;
 import com.setiawanpaiman.sunnyreader.data.model.Story;
 import com.setiawanpaiman.sunnyreader.domain.api.HackerNewsApi;
@@ -32,7 +31,7 @@ import java.util.List;
 import static junit.framework.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -90,15 +89,15 @@ public class HackerNewsServiceTest extends BaseTest {
         when(mHackerNewsPersistent.getTopStories(anyInt(), anyInt())).thenReturn(Observable.just(initTopStories(2, 5)));
         when(mHackerNewsApi.getStory(anyLong())).thenAnswer(storiesAnswer);
 
-        TestSubscriber<Story> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getTopStories().subscribe(testSubscriber);
+        TestSubscriber<List<Story>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getTopStories(10).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(1)).getTopStories();
-        verify(mHackerNewsPersistent, times(1)).saveTopStories(anyList());
-        verify(mHackerNewsPersistent, times(2)).getTopStories(0, Constants.PER_PAGE);
+        verify(mHackerNewsPersistent, times(1)).saveTopStories(anyListOf(Long.class));
+        verify(mHackerNewsPersistent, times(2)).getTopStories(0, 10);
         verify(mHackerNewsApi, times(4)).getStory(anyLong());
         verify(mHackerNewsPersistent, times(4)).saveStory(any(Story.class));
         testSubscriber.assertNoErrors();
-        List<Story> emittedStories = testSubscriber.getOnNextEvents();
+        List<Story> emittedStories = testSubscriber.getOnNextEvents().get(0);
         assertEquals(4, emittedStories.size());
         assertEquals(MockStory.STORY2, emittedStories.get(0));
         assertEquals(MockStory.STORY3, emittedStories.get(1));
@@ -112,15 +111,15 @@ public class HackerNewsServiceTest extends BaseTest {
         when(mHackerNewsPersistent.getTopStories(anyInt(), anyInt())).thenReturn(Observable.just(initTopStories(3, 4)));
         when(mHackerNewsApi.getStory(anyLong())).thenAnswer(storiesAnswer);
 
-        TestSubscriber<Story> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getTopStories(2).subscribe(testSubscriber);
+        TestSubscriber<List<Story>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getTopStories(2, 10).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(0)).getTopStories();
-        verify(mHackerNewsPersistent, times(0)).saveTopStories(anyList());
-        verify(mHackerNewsPersistent, times(1)).getTopStories(10, Constants.PER_PAGE);
+        verify(mHackerNewsPersistent, times(0)).saveTopStories(anyListOf(Long.class));
+        verify(mHackerNewsPersistent, times(1)).getTopStories(10, 10);
         verify(mHackerNewsApi, times(2)).getStory(anyLong());
         verify(mHackerNewsPersistent, times(2)).saveStory(any(Story.class));
         testSubscriber.assertNoErrors();
-        List<Story> emittedStories = testSubscriber.getOnNextEvents();
+        List<Story> emittedStories = testSubscriber.getOnNextEvents().get(0);
         assertEquals(2, emittedStories.size());
         assertEquals(MockStory.STORY3, emittedStories.get(0));
         assertEquals(MockStory.STORY4, emittedStories.get(1));
@@ -133,15 +132,15 @@ public class HackerNewsServiceTest extends BaseTest {
                 .thenReturn(Observable.<List<Long>>empty()).thenReturn(Observable.just(initTopStories(2, 4)));
         when(mHackerNewsApi.getStory(anyLong())).thenAnswer(storiesAnswer);
 
-        TestSubscriber<Story> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getTopStories(2).subscribe(testSubscriber);
+        TestSubscriber<List<Story>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getTopStories(2, 10).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(1)).getTopStories();
-        verify(mHackerNewsPersistent, times(1)).saveTopStories(anyList());
-        verify(mHackerNewsPersistent, times(3)).getTopStories(10, Constants.PER_PAGE);
+        verify(mHackerNewsPersistent, times(1)).saveTopStories(anyListOf(Long.class));
+        verify(mHackerNewsPersistent, times(3)).getTopStories(10, 10);
         verify(mHackerNewsApi, times(3)).getStory(anyLong());
         verify(mHackerNewsPersistent, times(3)).saveStory(any(Story.class));
         testSubscriber.assertNoErrors();
-        List<Story> emittedStories = testSubscriber.getOnNextEvents();
+        List<Story> emittedStories = testSubscriber.getOnNextEvents().get(0);
         assertEquals(3, emittedStories.size());
         assertEquals(MockStory.STORY2, emittedStories.get(0));
         assertEquals(MockStory.STORY3, emittedStories.get(1));
@@ -155,21 +154,21 @@ public class HackerNewsServiceTest extends BaseTest {
         when(mHackerNewsApi.getStory(anyLong()))
                 .thenReturn(Observable.<Story> just(null))
                 .thenReturn(Observable.<Story> just(null))
-                .thenReturn(Observable.just(MockStory.STORY1));
+                .thenReturn(Observable.just(MockStory.STORY4));
         when(mHackerNewsPersistent.getStory(anyLong())).thenAnswer(storiesAnswer);
 
-        TestSubscriber<Story> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getTopStories(1).observeOn(AndroidSchedulers.mainThread(), true).subscribe(testSubscriber);
+        TestSubscriber<List<Story>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getTopStories(10).observeOn(AndroidSchedulers.mainThread(), true).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(1)).getTopStories();
-        verify(mHackerNewsPersistent, times(1)).saveTopStories(anyList());
-        verify(mHackerNewsPersistent, times(2)).getTopStories(0, Constants.PER_PAGE);
+        verify(mHackerNewsPersistent, times(1)).saveTopStories(anyListOf(Long.class));
+        verify(mHackerNewsPersistent, times(2)).getTopStories(0, 10);
         verify(mHackerNewsApi, times(3)).getStory(anyLong());
         verify(mHackerNewsPersistent, times(3)).getStory(anyLong());
         verify(mHackerNewsPersistent, times(1)).saveStory(any(Story.class));
         testSubscriber.assertNoErrors();
-        List<Story> emittedStories = testSubscriber.getOnNextEvents();
+        List<Story> emittedStories = testSubscriber.getOnNextEvents().get(0);
         assertEquals(1, emittedStories.size());
-        assertEquals(MockStory.STORY1, emittedStories.get(0));
+        assertEquals(MockStory.STORY4, emittedStories.get(0));
     }
 
     @Test
@@ -178,20 +177,20 @@ public class HackerNewsServiceTest extends BaseTest {
         when(mHackerNewsPersistent.getTopStories(anyInt(), anyInt())).thenReturn(Observable.just(initTopStories(2, 4)));
         when(mHackerNewsApi.getStory(anyLong()))
                 .thenReturn(Observable.<Story> error(new Exception())).thenAnswer(storiesAnswer);
-        when(mHackerNewsPersistent.getStory(anyLong())).thenReturn(Observable.just(MockStory.STORY6));
+        when(mHackerNewsPersistent.getStory(anyLong())).thenReturn(Observable.just(MockStory.STORY2));
 
-        TestSubscriber<Story> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getTopStories(1).observeOn(AndroidSchedulers.mainThread(), true).subscribe(testSubscriber);
+        TestSubscriber<List<Story>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getTopStories(10).observeOn(AndroidSchedulers.mainThread(), true).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(1)).getTopStories();
-        verify(mHackerNewsPersistent, times(1)).saveTopStories(anyList());
-        verify(mHackerNewsPersistent, times(2)).getTopStories(0, Constants.PER_PAGE);
+        verify(mHackerNewsPersistent, times(1)).saveTopStories(anyListOf(Long.class));
+        verify(mHackerNewsPersistent, times(2)).getTopStories(0, 10);
         verify(mHackerNewsApi, times(3)).getStory(anyLong());
         verify(mHackerNewsPersistent, times(3)).getStory(anyLong());
         verify(mHackerNewsPersistent, times(2)).saveStory(any(Story.class));
         testSubscriber.assertNoErrors();
-        List<Story> emittedStories = testSubscriber.getOnNextEvents();
+        List<Story> emittedStories = testSubscriber.getOnNextEvents().get(0);
         assertEquals(3, emittedStories.size());
-        assertEquals(MockStory.STORY6, emittedStories.get(0));
+        assertEquals(MockStory.STORY2, emittedStories.get(0));
         assertEquals(MockStory.STORY3, emittedStories.get(1));
         assertEquals(MockStory.STORY4, emittedStories.get(2));
     }
@@ -201,12 +200,12 @@ public class HackerNewsServiceTest extends BaseTest {
         when(mHackerNewsApi.getComment(anyLong())).thenAnswer(commentsAnswer);
         when(mHackerNewsPersistent.getComment(anyLong())).thenAnswer(commentsAnswer);
 
-        TestSubscriber<Comment> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getComments(MockStory.STORY_COMMENT2).subscribe(testSubscriber);
+        TestSubscriber<List<Comment>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getComments(MockStory.STORY_COMMENT2, 10).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(6)).getComment(anyLong());
         verify(mHackerNewsPersistent, times(6)).saveComment(any(Comment.class));
         testSubscriber.assertNoErrors();
-        List<Comment> emittedComments = testSubscriber.getOnNextEvents();
+        List<Comment> emittedComments = testSubscriber.getOnNextEvents().get(0);
         assertEquals(6, emittedComments.size());
         assertEquals(MockComment.COMMENT2, emittedComments.get(0));
         assertEquals(MockComment.COMMENT21, emittedComments.get(1));
@@ -228,24 +227,20 @@ public class HackerNewsServiceTest extends BaseTest {
         when(mHackerNewsApi.getComment(anyLong())).thenAnswer(commentsAnswer);
         when(mHackerNewsPersistent.getComment(anyLong())).thenAnswer(commentsAnswer);
 
-        TestSubscriber<Comment> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getComments(MockStory.STORY_COMMENT3).subscribe(testSubscriber);
+        TestSubscriber<List<Comment>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getComments(MockStory.STORY_COMMENT3, 10).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(6)).getComment(anyLong());
         verify(mHackerNewsPersistent, times(6)).saveComment(any(Comment.class));
         testSubscriber.assertNoErrors();
-        List<Comment> emittedComments = testSubscriber.getOnNextEvents();
-        assertEquals(5, emittedComments.size());
+        List<Comment> emittedComments = testSubscriber.getOnNextEvents().get(0);
+        assertEquals(3, emittedComments.size());
         assertEquals(MockComment.COMMENT3, emittedComments.get(0));
-        assertEquals(MockComment.COMMENT311, emittedComments.get(1));
-        assertEquals(MockComment.COMMENT312, emittedComments.get(2));
-        assertEquals(MockComment.COMMENT32, emittedComments.get(3));
-        assertEquals(MockComment.COMMENT321, emittedComments.get(4));
+        assertEquals(MockComment.COMMENT32, emittedComments.get(1));
+        assertEquals(MockComment.COMMENT321, emittedComments.get(2));
 
         assertEquals(0, emittedComments.get(0).getDepth());
-        assertEquals(2, emittedComments.get(1).getDepth());
+        assertEquals(1, emittedComments.get(1).getDepth());
         assertEquals(2, emittedComments.get(2).getDepth());
-        assertEquals(1, emittedComments.get(3).getDepth());
-        assertEquals(2, emittedComments.get(4).getDepth());
     }
 
     @Test
@@ -255,12 +250,12 @@ public class HackerNewsServiceTest extends BaseTest {
                 .thenReturn(Observable.<Comment> just(null)).thenAnswer(commentsAnswer);
         when(mHackerNewsPersistent.getComment(anyLong())).thenAnswer(commentsAnswer);
 
-        TestSubscriber<Comment> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getComments(MockStory.STORY_COMMENT3).subscribe(testSubscriber);
+        TestSubscriber<List<Comment>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getComments(MockStory.STORY_COMMENT3, 10).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(4)).getComment(anyLong());
         verify(mHackerNewsPersistent, times(3)).saveComment(any(Comment.class));
         testSubscriber.assertNoErrors();
-        List<Comment> emittedComments = testSubscriber.getOnNextEvents();
+        List<Comment> emittedComments = testSubscriber.getOnNextEvents().get(0);
         assertEquals(3, emittedComments.size());
         assertEquals(MockComment.COMMENT3, emittedComments.get(0));
         assertEquals(MockComment.COMMENT32, emittedComments.get(1));
@@ -280,25 +275,19 @@ public class HackerNewsServiceTest extends BaseTest {
                 .thenAnswer(commentsAnswer)
                 .thenReturn(Observable.just(MockComment.COMMENT22)).thenAnswer(commentsAnswer);
 
-        TestSubscriber<Comment> testSubscriber = new TestSubscriber<>();
-        mHackerNewsService.getComments(MockStory.STORY_COMMENT3).subscribe(testSubscriber);
+        TestSubscriber<List<Comment>> testSubscriber = new TestSubscriber<>();
+        mHackerNewsService.getComments(MockStory.STORY_COMMENT3, 10).subscribe(testSubscriber);
         verify(mHackerNewsApi, times(6)).getComment(anyLong());
         verify(mHackerNewsPersistent, times(5)).saveComment(any(Comment.class));
         testSubscriber.assertNoErrors();
-        List<Comment> emittedComments = testSubscriber.getOnNextEvents();
-        assertEquals(6, emittedComments.size());
+        List<Comment> emittedComments = testSubscriber.getOnNextEvents().get(0);
+        assertEquals(3, emittedComments.size());
         assertEquals(MockComment.COMMENT3, emittedComments.get(0));
-        assertEquals(MockComment.COMMENT22, emittedComments.get(1));
-        assertEquals(MockComment.COMMENT221, emittedComments.get(2));
-        assertEquals(MockComment.COMMENT222, emittedComments.get(3));
-        assertEquals(MockComment.COMMENT32, emittedComments.get(4));
-        assertEquals(MockComment.COMMENT321, emittedComments.get(5));
+        assertEquals(MockComment.COMMENT32, emittedComments.get(1));
+        assertEquals(MockComment.COMMENT321, emittedComments.get(2));
 
         assertEquals(0, emittedComments.get(0).getDepth());
         assertEquals(1, emittedComments.get(1).getDepth());
         assertEquals(2, emittedComments.get(2).getDepth());
-        assertEquals(2, emittedComments.get(3).getDepth());
-        assertEquals(1, emittedComments.get(4).getDepth());
-        assertEquals(2, emittedComments.get(5).getDepth());
     }
 }

--- a/app/src/test/java/com/setiawanpaiman/sunnyreader/testcase/ui/presenter/StoryDetailPresenterTest.java
+++ b/app/src/test/java/com/setiawanpaiman/sunnyreader/testcase/ui/presenter/StoryDetailPresenterTest.java
@@ -1,0 +1,199 @@
+package com.setiawanpaiman.sunnyreader.testcase.ui.presenter;
+
+import com.setiawanpaiman.sunnyreader.Constants;
+import com.setiawanpaiman.sunnyreader.data.model.Comment;
+import com.setiawanpaiman.sunnyreader.data.model.Story;
+import com.setiawanpaiman.sunnyreader.domain.service.IHackerNewsService;
+import com.setiawanpaiman.sunnyreader.mockdata.MockComment;
+import com.setiawanpaiman.sunnyreader.mockdata.MockStory;
+import com.setiawanpaiman.sunnyreader.testcase.BaseTest;
+import com.setiawanpaiman.sunnyreader.ui.presenter.EndlessListContract;
+import com.setiawanpaiman.sunnyreader.ui.presenter.StoryDetailPresenter;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.robolectric.RobolectricGradleTestRunner;
+
+import rx.Observable;
+import rx.schedulers.Schedulers;
+import rx.schedulers.TestScheduler;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricGradleTestRunner.class)
+public class StoryDetailPresenterTest extends BaseTest {
+
+    @Rule
+    public MockitoRule mMockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    IHackerNewsService mHackerNewsService;
+
+    @Mock
+    EndlessListContract.View<List<Comment>> mView;
+
+    TestScheduler mTestScheduler = new TestScheduler();
+
+    StoryDetailPresenter mPresenter;
+
+    List<Comment> mMockComments = Arrays.asList(MockComment.COMMENT2, MockComment.COMMENT21, MockComment.COMMENT21,
+            MockComment.COMMENT22, MockComment.COMMENT221, MockComment.COMMENT222);
+
+    Story mStory = MockStory.STORY_COMMENT2;
+
+    @Before
+    public void setUp() throws Exception {
+        mPresenter = new StoryDetailPresenter(mView, Schedulers.immediate(), mHackerNewsService, mStory);
+    }
+
+    @Test
+    public void testRestoreInstanceState() throws Exception {
+        mPresenter.onRestoreInstanceState(10);
+        assertEquals(10, mPresenter.getCurrentPage());
+    }
+
+    @Test
+    public void testLoadDataRefresh() throws Exception {
+        arrangePreLoadData();
+        mPresenter.loadData(true);
+        assertPostSuccessLoadData(1, true);
+    }
+
+    @Test
+    public void testLoadDataNotRefresh() throws Exception {
+        arrangePreLoadData();
+        mPresenter.loadData(false);
+        assertPostSuccessLoadData(2, false);
+    }
+
+    @Test
+    public void testLoadDataRefreshAfterOnRestoreInstanceState() throws Exception {
+        arrangePreLoadData();
+        mPresenter.onRestoreInstanceState(5);
+        mPresenter.loadData(true);
+        assertPostSuccessLoadData(1, true);
+    }
+
+    @Test
+    public void testLoadDataNotRefreshAfterOnRestoreInstanceState() throws Exception {
+        arrangePreLoadData();
+        mPresenter.onRestoreInstanceState(5);
+        mPresenter.loadData(false);
+        assertPostSuccessLoadData(6, false);
+    }
+
+    @Test
+    public void testErrorLoadDataRefresh() throws Exception {
+        when(mHackerNewsService.getComments(eq(mStory), anyInt(), anyInt()))
+                .thenReturn(Observable.<List<Comment>> error(new Exception()));
+        mPresenter.loadData(true);
+        assertPostErrorLoadData(1, 1, true);
+    }
+
+    @Test
+    public void testErrorLoadDataNotRefresh() throws Exception {
+        when(mHackerNewsService.getComments(eq(mStory), anyInt(), anyInt()))
+                .thenReturn(Observable.<List<Comment>> error(new Exception()));
+        mPresenter.loadData(false);
+        assertPostErrorLoadData(1, 2, false);
+    }
+
+    @Test
+    public void testLoadDataSuccessShouldTriggerLoadMore() throws Exception {
+        arrangePreLoadData();
+        mPresenter.loadData(true);
+
+        boolean inProgress = mPresenter.isLoadIsInProgress();
+        assertTrue(inProgress);
+
+        mPresenter.loadData(false);
+        mTestScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
+
+        inProgress = mPresenter.isLoadIsInProgress();
+        assertTrue(inProgress);
+
+        mTestScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
+
+        inProgress = mPresenter.isLoadIsInProgress();
+        assertFalse(inProgress);
+
+        assertEquals(2, mPresenter.getCurrentPage());
+        verify(mHackerNewsService, times(1)).getComments(mStory, 1, Constants.PER_PAGE);
+        verify(mHackerNewsService, times(1)).getComments(mStory, 2, Constants.PER_PAGE);
+        verify(mView, times(1)).setProgressVisibility(true, false);
+        verify(mView, times(1)).setProgressVisibility(false, false);
+        verify(mView, times(1)).setProgressVisibility(true, true);
+        verify(mView, times(1)).setProgressVisibility(false, true);
+        verify(mView, times(1)).showData(mMockComments, true);
+        verify(mView, times(1)).showData(mMockComments, false);
+    }
+
+    @Test
+    public void testOnDestroy() throws Exception {
+        arrangePreLoadData();
+        mPresenter.loadData(true);
+
+        boolean inProgress = mPresenter.isLoadIsInProgress();
+        assertTrue(inProgress);
+
+        mPresenter.onDestroy();
+        inProgress = mPresenter.isLoadIsInProgress();
+        assertFalse(inProgress);
+
+        mTestScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
+
+        verify(mHackerNewsService, times(1)).getComments(mStory, 1, Constants.PER_PAGE);
+        verify(mView, times(1)).setProgressVisibility(true, true);
+        verify(mView, times(0)).setProgressVisibility(false, true);
+        verify(mView, times(0)).showData(anyListOf(Comment.class), anyBoolean());
+    }
+
+    private void arrangePreLoadData() {
+        when(mHackerNewsService.getComments(eq(mStory), anyInt(), anyInt()))
+                .thenReturn(Observable.just(mMockComments).delay(2, TimeUnit.SECONDS, mTestScheduler));
+
+        boolean inProgress = mPresenter.isLoadIsInProgress();
+        assertFalse(inProgress);
+    }
+
+    private void assertPostSuccessLoadData(int expectedPage, boolean refresh) {
+        boolean inProgress = mPresenter.isLoadIsInProgress();
+        assertTrue(inProgress);
+
+        mTestScheduler.advanceTimeBy(2, TimeUnit.SECONDS);
+
+        inProgress = mPresenter.isLoadIsInProgress();
+        assertFalse(inProgress);
+
+        assertEquals(expectedPage, mPresenter.getCurrentPage());
+        verify(mHackerNewsService, times(1)).getComments(mStory, expectedPage, Constants.PER_PAGE);
+        verify(mView, times(1)).setProgressVisibility(true, refresh);
+        verify(mView, times(1)).setProgressVisibility(false, refresh);
+        verify(mView, times(1)).showData(mMockComments, refresh);
+    }
+
+    private void assertPostErrorLoadData(int expectedCurrentPage, int pageLoaded, boolean refresh) {
+        assertEquals(expectedCurrentPage, mPresenter.getCurrentPage());
+        verify(mHackerNewsService, times(1)).getComments(mStory, pageLoaded, Constants.PER_PAGE);
+        verify(mView, times(1)).setProgressVisibility(true, refresh);
+        verify(mView, times(1)).setProgressVisibility(false, refresh);
+    }
+}


### PR DESCRIPTION
RxJava's `concatMap` operator performance is terrible. I've tried to do benchmark by comparing `concatMap` and `flatMap` combined with manual ordering. The result is `flatMap` combined with manual ordering is far more faster (4-5 times faster) compared with `concatMap`.
